### PR TITLE
Use Generic Connection for JDBCExecute

### DIFF
--- a/docs-src/content/execute/index.md
+++ b/docs-src/content/execute/index.md
@@ -57,9 +57,12 @@ The `JDBCExecute` executes a SQL statement against an external JDBC connection.
 |name|String|true|{{< readfile file="/content/partials/fields/stageName.md" markdown="true" >}}|
 |environments|Array[String]|true|{{< readfile file="/content/partials/fields/environments.md" markdown="true" >}}|
 |inputURI|URI|true|{{< readfile file="/content/partials/fields/inputURI.md" markdown="true" >}}|
+|url|String|true|{{< readfile file="/content/partials/fields/jdbcURL.md" markdown="true" >}}|
+|user|String|false|Database username to connect as. Optional, can also be in the url or params.|
+|password|String|false|Database password for the given user. Optional, can also be in the url or params.|
 |authentication|Map[String, String]|false|{{< readfile file="/content/partials/fields/authentication.md" markdown="true" >}}|
 |sqlParams|Map[String, String]|false|{{< readfile file="/content/partials/fields/sqlParams.md" markdown="true" >}}|
-|params|Map[String, String]|true|{{< readfile file="/content/partials/fields/params.md" markdown="true" >}}. Currently requires `jdbcType`, `serverName`, `databaseName`, `hostNameInCertificate`, `serverPort`, `user` and `password` to be set here - see example below. Allowed values for `jdbcType` is currently only `SQLServer`.|
+|params|Map[String, String]|true|{{< readfile file="/content/partials/fields/params.md" markdown="true" >}}. All params will be added to the Connection Properties.|
 
 ### Examples
 
@@ -69,16 +72,13 @@ The `JDBCExecute` executes a SQL statement against an external JDBC connection.
     "name": "update the load date table",
     "environments": ["production", "test"],
     "inputURI": "hdfs://datalake/sql/update_customer_load_date.sql",          
+    "url": "jdbc:postgresql://localhost/test",
+    "user": "test",
+    "password": "test",
     "sqlParams": {
         "current_timestamp": "2018-11-24 14:48:56"
     },    
     "params": {
-        "jdbcType": "SQLServer",
-        "url": "jdbc:sqlserver://myserver.database.windows.net",
-        "databaseName": "mydatabase",
-        "serverPort": 1433,
-        "user": "mydbuser",
-        "password": "mydbpassword",
     }
 }
 ```

--- a/src/main/scala/au/com/agl/arc/api/API.scala
+++ b/src/main/scala/au/com/agl/arc/api/API.scala
@@ -217,7 +217,10 @@ object API {
 
   sealed trait Execute extends PipelineStage
 
-  case class JDBCExecute(name: String, inputURI: URI, sql: String, sqlParams: Map[String, String], params: Map[String, String]) extends Execute { val getType = "JDBCExecute" }
+  case class JDBCExecute(name: String, inputURI: URI, url: String,
+                        user: Option[String], password: Option[String], 
+                        sql: String, sqlParams: Map[String, String], 
+                        params: Map[String, String]) extends Execute { val getType = "JDBCExecute" }
 
   case class HTTPExecute(name: String, uri: URI, headers: Map[String, String], payloads: Map[String, String], validStatusCodes: Option[List[Int]], params: Map[String, String]) extends Execute  { val getType = "HTTPExecute" }
 

--- a/src/main/scala/au/com/agl/arc/execute/JDBCExecute.scala
+++ b/src/main/scala/au/com/agl/arc/execute/JDBCExecute.scala
@@ -8,6 +8,7 @@ import java.sql.ResultSet
 import java.sql.SQLException
 import java.util.concurrent.Executors
 import java.util.concurrent.Future
+import java.util.Properties
 
 import com.microsoft.sqlserver.jdbc.SQLServerDataSource
 
@@ -15,56 +16,63 @@ import org.apache.spark.sql._
 
 import au.com.agl.arc.api.API._
 import au.com.agl.arc.util._
+import au.com.agl.arc.util.ControlUtils._
 
 object JDBCExecute {
 
+  def getConnection(url: String, user: Option[String], password: Option[String], params: Map[String, String]): Connection = {
+    val _user = user.orElse(params.get("user"))
+    val _password = password.orElse(params.get("password"))
+
+    (_user, _password) match {
+      case (Some(u), Some(p)) =>
+        if (params.isEmpty) {
+          DriverManager.getConnection(url, u, p)
+        } else {
+          val props = new Properties()
+          props.setProperty("user", u)
+          props.setProperty("password", p)
+          for ( (k,v) <- params) {
+            props.setProperty(k, v)
+          }
+          DriverManager.getConnection(url, props)
+        }
+      case _ =>
+        DriverManager.getConnection(url)
+    }
+  }
+
   def execute(exec: JDBCExecute)(implicit spark: SparkSession, logger: au.com.agl.arc.util.log.logger.Logger): Unit = {
+    import exec._
+
     val startTime = System.currentTimeMillis() 
     val stageDetail = new java.util.HashMap[String, Object]()
-    stageDetail.put("type", exec.getType)
-    stageDetail.put("name", exec.name)
-    stageDetail.put("inputURI", exec.inputURI.toString)     
-    stageDetail.put("sqlParams", exec.sqlParams.asJava)
-
-    // replace sql parameters
-    val stmt = SQLUtils.injectParameters(exec.sql, exec.sqlParams)
-
-    stageDetail.put("sql", stmt)     
+    stageDetail.put("type", getType)
+    stageDetail.put("name", name)
+    stageDetail.put("inputURI", inputURI.toString)     
+    stageDetail.put("sqlParams", sqlParams.asJava)
 
     logger.info()
       .field("event", "enter")
       .map("stage", stageDetail)      
       .log()
 
-    val conn = try {
-      exec.params.get("jdbcType") match {
-        case Some("SQLServer") => Option(getSQLServerConnection(exec.params))
-        case Some("Derby") => Option(getDerbyConnection(exec.params))        
-        case _ => throw new Exception (s"""unknown jdbcType: '${exec.params.get("jdbcType").getOrElse("")}'""")
-      }
-    } catch {
-      case e: Exception => throw new Exception(e) with DetailException {
-        override val detail = stageDetail          
-      }  
-    }
+    try {
+      // replace sql parameters
+      val sqlToExecute = SQLUtils.injectParameters(sql, sqlParams)
+      stageDetail.put("sql", sqlToExecute)     
 
-    val result = try {
-      for (c <- conn) {
-        c.createStatement().execute(stmt)
+      using(getConnection(url, user, password, params)) { conn =>
+        using(conn.createStatement) { stmt =>
+          stmt.execute(sqlToExecute)
+        }
       }
+
     } catch {
       case e: Exception => throw new Exception(e) with DetailException {
-        override val detail = stageDetail          
+        override val detail = stageDetail         
       }
-    } finally {
-      try {
-        conn.foreach(_.close())
-      } catch {
-        case e: Exception => throw new Exception(e) with DetailException {
-          override val detail = stageDetail          
-        }  
-      }
-    } 
+    }
 
     logger.info()
       .field("event", "exit")
@@ -73,29 +81,4 @@ object JDBCExecute {
       .log()   
   }
 
-  private def getSQLServerConnection(params: Map[String, String]): Connection = {
-    val ds = new SQLServerDataSource()
-
-    for (url <- params.get("url")) {
-      ds.setURL(url)    
-    }        
-    for (user <- params.get("user")) {
-      ds.setUser(user)    
-    }    
-    for (password <- params.get("password")) {
-      ds.setPassword(password)    
-    }        
-    for (serverPort <- params.get("serverPort")) {
-      ds.setPortNumber(serverPort.toInt)
-    }
-    for (databaseName <- params.get("databaseName")) {
-      ds.setDatabaseName(databaseName)    
-    }         
-
-    ds.getConnection()
-  }
-
-  private def getDerbyConnection(params: Map[String, String]): Connection = {
-    DriverManager.getConnection(params.get("serverName").getOrElse(""))    
-  }  
 }

--- a/src/main/scala/au/com/agl/arc/execute/JDBCExecute.scala
+++ b/src/main/scala/au/com/agl/arc/execute/JDBCExecute.scala
@@ -52,16 +52,16 @@ object JDBCExecute {
     stageDetail.put("inputURI", inputURI.toString)     
     stageDetail.put("sqlParams", sqlParams.asJava)
 
+    // replace sql parameters
+    val sqlToExecute = SQLUtils.injectParameters(sql, sqlParams)
+    stageDetail.put("sql", sqlToExecute)     
+
     logger.info()
       .field("event", "enter")
       .map("stage", stageDetail)      
       .log()
 
     try {
-      // replace sql parameters
-      val sqlToExecute = SQLUtils.injectParameters(sql, sqlParams)
-      stageDetail.put("sql", sqlToExecute)     
-
       using(getConnection(url, user, password, params)) { conn =>
         using(conn.createStatement) { stmt =>
           stmt.execute(sqlToExecute)

--- a/src/main/scala/au/com/agl/arc/util/ControlUtils.scala
+++ b/src/main/scala/au/com/agl/arc/util/ControlUtils.scala
@@ -1,0 +1,12 @@
+package au.com.agl.arc.util
+
+object ControlUtils {
+
+  def using[A <: AutoCloseable, B](param: A)(f: A => B): B =
+    try {
+      f(param)
+    } finally {
+      param.close()
+    }
+
+}

--- a/src/main/scala/au/com/agl/arc/util/JDBCUtils.scala
+++ b/src/main/scala/au/com/agl/arc/util/JDBCUtils.scala
@@ -1,0 +1,16 @@
+package au.com.agl.arc.util
+
+import java.sql.DriverManager
+
+object JDBCUtils {
+
+    def checkDriverExists(url: String): Boolean = {
+        try {
+            DriverManager.getDriver(url)
+            true
+        } catch {
+            case _: Throwable => false
+        }
+    }
+
+}

--- a/src/test/scala/au/com/agl/arc/execute/JDBCExecuteSuite.scala
+++ b/src/test/scala/au/com/agl/arc/execute/JDBCExecuteSuite.scala
@@ -77,8 +77,11 @@ class JDBCExecuteSuite extends FunSuite with BeforeAndAfter {
       JDBCExecute(
         name=outputView, 
         inputURI=new URI(testURI), 
+        url = url,
+        user = None,
+        password = None,
         sql=s"CREATE TABLE ${newTable} (COLUMN0 VARCHAR(100) NOT NULL, PRIMARY KEY (COLUMN0))", 
-        params= Map("jdbcType" -> "Derby", "serverName" -> url), 
+        params= Map.empty, 
         sqlParams=Map.empty
       )
     )
@@ -103,8 +106,11 @@ class JDBCExecuteSuite extends FunSuite with BeforeAndAfter {
       JDBCExecute(
         name=outputView, 
         inputURI=new URI(testURI), 
+        url = url,
+        user = None,
+        password = None,
         sql=s"CREATE TABLE ${newTable} (${newColumn} VARCHAR(100) NOT NULL, PRIMARY KEY (COLUMN0))", 
-        params= Map("jdbcType" -> "Derby", "serverName" -> url), 
+        params= Map.empty, 
         sqlParams=Map("column_name" -> "COLUMN0")
       )
     )
@@ -130,8 +136,11 @@ class JDBCExecuteSuite extends FunSuite with BeforeAndAfter {
         JDBCExecute(
           name=outputView, 
           inputURI=new URI(testURI), 
+          url = "jdbc:derby:invalid",
+          user = None,
+          password = None,
           sql=s"CREATE TABLE ${newTable} (COLUMN0 VARCHAR(100) NOT NULL, PRIMARY KEY (COLUMN0))", 
-          params= Map("jdbcType" -> "Derby", "serverName" -> "jdbc:derby:invalid"), 
+          params= Map.empty, 
           sqlParams=Map.empty
         )
       )
@@ -149,13 +158,16 @@ class JDBCExecuteSuite extends FunSuite with BeforeAndAfter {
         JDBCExecute(
           name=outputView, 
           inputURI=new URI(testURI), 
+          url = "0.0.0.0",
+          user = None,
+          password = None,
           sql=s"CREATE TABLE ${newTable} (COLUMN0 VARCHAR(100) NOT NULL, PRIMARY KEY (COLUMN0))", 
-          params= Map("jdbcType" -> "SQLServer", "url" -> "0.0.0.0"), 
+          params= Map.empty, 
           sqlParams=Map.empty
         )
       )
     }
-    assert(thrown.getMessage == "com.microsoft.sqlserver.jdbc.SQLServerException: The connection string contains a badly formed name or value.")
+    assert(thrown.getMessage == "java.sql.SQLException: No suitable driver found for 0.0.0.0")
   }    
 
   test("JDBCExecute: Bad jdbcType") {
@@ -168,12 +180,15 @@ class JDBCExecuteSuite extends FunSuite with BeforeAndAfter {
         JDBCExecute(
           name=outputView, 
           inputURI=new URI(testURI), 
+          url = "",
+          user = None,
+          password = None,
           sql=s"CREATE TABLE ${newTable} (COLUMN0 VARCHAR(100) NOT NULL, PRIMARY KEY (COLUMN0))", 
-          params= Map("jdbcType" -> "unknown"), 
+          params= Map.empty, 
           sqlParams=Map.empty
         )
       )
     }
-    assert(thrown.getMessage == "java.lang.Exception: unknown jdbcType: 'unknown'")
+    assert(thrown.getMessage == "java.sql.SQLException: No suitable driver found for ")
   }    
 }

--- a/src/test/scala/au/com/agl/arc/execute/JDBCExecuteSuite.scala
+++ b/src/test/scala/au/com/agl/arc/execute/JDBCExecuteSuite.scala
@@ -167,7 +167,7 @@ class JDBCExecuteSuite extends FunSuite with BeforeAndAfter {
         )
       )
     }
-    assert(thrown.getMessage == "java.sql.SQLException: No suitable driver found for 0.0.0.0")
+    assert(thrown.getMessage.contains("No suitable driver found"))
   }    
 
   test("JDBCExecute: Bad jdbcType") {


### PR DESCRIPTION
- Changed JDBCExecute to take url, user (optional) and password (optional)
- Should allow for generic connections to be created with vendor specific options in the url or connection properties
- Added a check to the config validation to confirm required JDBC Driver exists
- Added some utility methods to auto close connections, statements etc