### PR TITLE
Added hook for registering custom UDFs

### DIFF
--- a/src/main/scala/au/com/agl/arc/ARC.scala
+++ b/src/main/scala/au/com/agl/arc/ARC.scala
@@ -1,5 +1,7 @@
 package au.com.agl.arc
 
+import au.com.agl.arc.udf.UDF
+
 object ARC {
 
   import java.util.UUID
@@ -193,6 +195,7 @@ object ARC {
     val error: Boolean = pipelineConfig match {
       case Right(pipeline) =>
         try {
+          UDF.registerUDFs(spark.sqlContext)
           ARC.run(pipeline)(spark, logger)
           false
         } catch {

--- a/src/main/scala/au/com/agl/arc/udf/UDF.scala
+++ b/src/main/scala/au/com/agl/arc/udf/UDF.scala
@@ -1,0 +1,12 @@
+package au.com.agl.arc.udf
+
+import org.apache.spark.sql.SQLContext
+
+object UDF {
+
+  def registerUDFs(sqlContext: SQLContext): Unit = {
+    // register custom UDFs via sqlContext.udf.register("funcName", func )
+
+  }
+
+}


### PR DESCRIPTION
Simple hook for adding custom UDFs to extend Spark SQL.

UDFs will be registered prior to calling Arc.run. Overtime a library of useful UDFs can be added.